### PR TITLE
Update nuget.config + added psake task

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -3,4 +3,7 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+ <packageSources>
+   <add key="southside" value="https://www.myget.org/F/southside/" />
+  </packageSources>
 </configuration>

--- a/default.ps1
+++ b/default.ps1
@@ -13,9 +13,17 @@ properties {
     "tests\RabbitOperations.Collector.Tests.Unit/bin/$configuration/RabbitOperations.Collector.Tests.Unit.dll")
 }
 
+task validateProperties -Description "Validate the build script properties." -action {
+    assert( "debug","release" -contains $configuration ) `
+        "Invalid Configuration: $configuration : valid values are debug and release"
+
+    assert( "Any Cpu" -contains $platform ) `
+        "Invalid Platform: $platform : valid values are `"Any Cpu`""
+}
+
 task default -depends Build
 
-task build -Description "Build application.  Runs tests" -depends cleanBuildOutput, version, compile, test {
+task build -Description "Build application.  Runs tests" -depends validateProperties, cleanBuildOutput, version, compile, test {
 }
 
 task quickBuild -Description "Build application no tests" -depends cleanBuildOutput, version, compile {


### PR DESCRIPTION
1.) Added the southside nuget feed to the nuget.config file.  This is to prevent users from having to set this up manually.

2.) Added the psake validation task simply verifies that the properties passed in, by a user or CI server, are values that are sane.